### PR TITLE
Show bug with \ still in string

### DIFF
--- a/src/test/java/org/tools4j/spockito/FaqTest.java
+++ b/src/test/java/org/tools4j/spockito/FaqTest.java
@@ -73,7 +73,10 @@ public class FaqTest {
             "|123%7c321|123|321|"
     })
     public void testWithPipe(String input, BigInteger locationId, BigInteger eventId) {
-        Assert.assertTrue(input.contains("|") || input.startsWith("123") && input.endsWith("321"));
+      Assert.assertTrue("Should start with 123", input.startsWith("123"));
+      Assert.assertTrue("Should end with 321", input.endsWith("321"));
+      Assert.assertTrue("Should contain a | or %7c", input.contains("|") || input.contains("%7c"));
+      Assert.assertFalse("Should not have a \\", input.contains("\\"));
     }
 
 }


### PR DESCRIPTION
@terzerm Here is the Issue I am running into.  The Pipe is still there when I escape it but when the data is received at the  method the `\` should be gone.